### PR TITLE
Prevent NullPointerExceptions when requirements catalogue is generated containing stories with no points

### DIFF
--- a/corejet-core/src/main/java/org/corejet/model/RequirementsCatalogue.java
+++ b/corejet-core/src/main/java/org/corejet/model/RequirementsCatalogue.java
@@ -127,7 +127,10 @@ public class RequirementsCatalogue implements Cloneable{
 				Story story = new Story();
 				story.setId(storyElement.getAttributeValue("id"));
 				story.setTitle(storyElement.getAttributeValue("title"));
-				story.setPoints(Integer.parseInt(storyElement.getAttributeValue("points")));
+				String points = storyElement.getAttributeValue("points");
+				if (null!=points && !"".equals(points.trim())) {
+					story.setPoints(Integer.parseInt(points));
+				}
 				story.setRequirementStatus(storyElement.getAttributeValue("requirementStatus"));
 				story.setRequirementResolution(storyElement.getAttributeValue("requirementResolution"));
 				story.setPriority(storyElement.getAttributeValue("priority"));


### PR DESCRIPTION
Prevent NullPointerExceptions when requirements catalogue is generated containing stories with no points
