### PR TITLE
Configuration.getPropertyOrDefault method - fix issue 10

### DIFF
--- a/corejet-core/src/main/java/org/corejet/Configuration.java
+++ b/corejet-core/src/main/java/org/corejet/Configuration.java
@@ -3,6 +3,7 @@ package org.corejet;
 import java.io.IOException;
 import java.util.Properties;
 
+import com.google.common.base.Strings;
 import com.google.common.io.Resources;
 
 public class Configuration {
@@ -31,6 +32,16 @@ public class Configuration {
 		return property+"";
 	}
 	
+	public static String getPropertyOrDefault(String propertyName, String defaultValue) {
+		String value = null;
+		try {
+			value = getProperty(propertyName);
+		} catch (RuntimeException e) {
+			// value remains null
+		}
+		return Strings.isNullOrEmpty(value) ? defaultValue : value;
+	}
+	
 	private static synchronized Configuration getInstance() {
 		if (instance==null) {
 			instance = new Configuration();
@@ -39,11 +50,7 @@ public class Configuration {
 	}
 	
 	public static String getBaseDirectory(){
-		try {
-			return getProperty("corejet.report.directory");
-		} catch (RuntimeException e) {
-			return "target/corejet";
-		}
+		return getPropertyOrDefault("corejet.report.directory", "target/corejet");
 	}
 
 }

--- a/corejet-core/src/test/java/org/corejet/ConfigurationTest.java
+++ b/corejet-core/src/test/java/org/corejet/ConfigurationTest.java
@@ -18,4 +18,9 @@ public class ConfigurationTest {
 		
 		Configuration.getProperty("missing.property");
 	}
+	
+	@Test
+	public void testGetPropertyOrDefault() {
+		assertEquals("defaultValue", Configuration.getPropertyOrDefault("missing.property", "defaultValue"));
+	}
 }

--- a/corejet-jira-story-repository/src/main/java/org/corejet/OfflineJiraStoryRepository.java
+++ b/corejet-jira-story-repository/src/main/java/org/corejet/OfflineJiraStoryRepository.java
@@ -45,11 +45,7 @@ public class OfflineJiraStoryRepository implements StoryRepository {
 	
 	// Allow users to specify an alternative cached requirements file
 	static {
-		String cachedRequirementsFileLocation = Configuration.getProperty(CACHED_REQUIREMENTS_FILE_PROPERTY);
-		if (null==cachedRequirementsFileLocation || "".equals(cachedRequirementsFileLocation)) {
-			// Fall back to the default location
-			cachedRequirementsFileLocation = DEFAULT_CACHED_REQUIREMENTS_FILE_LOCATION;
-		}
+		String cachedRequirementsFileLocation = Configuration.getPropertyOrDefault(CACHED_REQUIREMENTS_FILE_PROPERTY, DEFAULT_CACHED_REQUIREMENTS_FILE_LOCATION);
 		logger.debug("Cached requirements file location = {}", cachedRequirementsFileLocation);
 		corejetRequirementsInputFile = new File(cachedRequirementsFileLocation);
 	}


### PR DESCRIPTION
The existing code seems to vary in how it expects Configuration.getProperty to work, so I thought introducing an explicit 'or default' method would be the clearest solution, rather than returning null as discussed in https://github.com/corejet/corejet/issues/10