### PR TITLE
issue-14 - Get the summary of the epics as well as their issue numbers

### DIFF
--- a/corejet-core/pom.xml
+++ b/corejet-core/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>corejet</artifactId>
 		<groupId>org.corejet</groupId>
-		<version>0.28</version>
+		<version>0.29</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/corejet-gradle-plugin/src/main/resources/corejet-to-html.xsl
+++ b/corejet-gradle-plugin/src/main/resources/corejet-to-html.xsl
@@ -320,7 +320,7 @@
 	<xsl:template match="epic" mode="map">
                         {   
                            'id':    'epic-<xsl:value-of select="@id"/>',
-                           'name':  '<xsl:value-of select="@title"/>',
+                           'name':  '<xsl:value-of select="@id"/>: <xsl:value-of select="@title"/>',
                            'data': {
                                        '$area': <xsl:value-of select="sum(child::story/@points)"/> * 10,
                                        <xsl:variable name="num_passing_epic"><xsl:value-of select="count(story/scenario[@testStatus='pass'])"/></xsl:variable>
@@ -460,7 +460,7 @@
        				<xsl:if test="$total_running_scenarios_epic>0">
                         {   
                            'id':    'epic-running-<xsl:value-of select="@id"/>',
-                           'name':  '<xsl:value-of select="@title"/>',
+                           'name':  '<xsl:value-of select="@id"/>: <xsl:value-of select="@title"/>',
                            'data': {
                                        '$area': <xsl:value-of select="sum(child::story/@points)"/> * 10,
                                                       '$color': <xsl:choose>
@@ -535,7 +535,7 @@
        				<xsl:if test="$total_running_scenarios_epic>0">
                         {   
                            'id':    'epic-timing-<xsl:value-of select="@id"/>',
-                           'name':  '<xsl:value-of select="@title"/>',
+                           'name':  '<xsl:value-of select="@id"/>: <xsl:value-of select="@title"/>',
                            'data': {
                                        '$area': (<xsl:value-of select="sum(child::story/scenario/@duration) + 0.0001 "/> * 1000 ),
                                                       '$color': <xsl:choose>

--- a/corejet-jira-story-repository/pom.xml
+++ b/corejet-jira-story-repository/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>corejet</artifactId>
 		<groupId>org.corejet</groupId>
-		<version>0.28</version>
+		<version>0.29</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/corejet-junit-runner/pom.xml
+++ b/corejet-junit-runner/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>corejet</artifactId>
 		<groupId>org.corejet</groupId>
-		<version>0.28</version>
+		<version>0.29</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/corejet-maven-plugin/pom.xml
+++ b/corejet-maven-plugin/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>corejet</artifactId>
 		<groupId>org.corejet</groupId>
-		<version>0.28</version>
+		<version>0.29</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/corejet-maven-plugin/src/main/resources/corejet-to-html.xsl
+++ b/corejet-maven-plugin/src/main/resources/corejet-to-html.xsl
@@ -320,7 +320,7 @@
 	<xsl:template match="epic" mode="map">
                         {   
                            'id':    'epic-<xsl:value-of select="@id"/>',
-                           'name':  '<xsl:value-of select="@title"/>',
+                           'name':  '<xsl:value-of select="@id"/>: <xsl:value-of select="@title"/>',
                            'data': {
                                        '$area': <xsl:value-of select="sum(child::story/@points)"/> * 10,
                                        <xsl:variable name="num_passing_epic"><xsl:value-of select="count(story/scenario[@testStatus='pass'])"/></xsl:variable>
@@ -460,7 +460,7 @@
        				<xsl:if test="$total_running_scenarios_epic>0">
                         {   
                            'id':    'epic-running-<xsl:value-of select="@id"/>',
-                           'name':  '<xsl:value-of select="@title"/>',
+                           'name':  '<xsl:value-of select="@id"/>: <xsl:value-of select="@title"/>',
                            'data': {
                                        '$area': <xsl:value-of select="sum(child::story/@points)"/> * 10,
                                                       '$color': <xsl:choose>
@@ -535,7 +535,7 @@
        				<xsl:if test="$total_running_scenarios_epic>0">
                         {   
                            'id':    'epic-timing-<xsl:value-of select="@id"/>',
-                           'name':  '<xsl:value-of select="@title"/>',
+                           'name':  '<xsl:value-of select="@id"/>: <xsl:value-of select="@title"/>',
                            'data': {
                                        '$area': (<xsl:value-of select="sum(child::story/scenario/@duration) + 0.0001 "/> * 1000 ),
                                                       '$color': <xsl:choose>

--- a/corejet-pageobject-support/pom.xml
+++ b/corejet-pageobject-support/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>corejet</artifactId>
 		<groupId>org.corejet</groupId>
-		<version>0.28</version>
+		<version>0.29</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/corejet-visualization/pom.xml
+++ b/corejet-visualization/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>corejet</artifactId>
 		<groupId>org.corejet</groupId>
-		<version>0.28</version>
+		<version>0.29</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.28
+version = 0.29

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>org.corejet</groupId>
 	<artifactId>corejet</artifactId>
-	<version>0.28</version>
+	<version>0.29</version>
 	<packaging>pom</packaging>
 	<url>http://corejet.org</url>
 	<licenses>


### PR DESCRIPTION
This pull request fixes an issue whereby the epic titles are not always shown in the html report:
- Improves the chances of finding an epic for each story by falling back to getting the `"customfield_"+this.epicFieldId` property as a String if it is not a `JSONObject`
- If the `epicAsString` value is an issue key rather than a descriptive value the Summary is retrieved from JIRA and set as the `title` field on the `Epic`
